### PR TITLE
refactor(bytes): optimize Format method for HexBytes

### DIFF
--- a/bytes/bytes.go
+++ b/bytes/bytes.go
@@ -58,8 +58,8 @@ func (bz HexBytes) String() string {
 func (bz HexBytes) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'p':
-		s.Write([]byte(fmt.Sprintf("%p", bz))) //nolint: errcheck
+		fmt.Fprintf(s, "%p", bz) //nolint: errcheck
 	default:
-		s.Write([]byte(fmt.Sprintf("%X", []byte(bz)))) //nolint: errcheck
+		fmt.Fprintf(s, "%X", []byte(bz)) //nolint: errcheck
 	}
 }


### PR DESCRIPTION
- Simplified the Format method by using fmt.Fprintf to directly convert HexBytes to a string and write it to fmt.State.
- Reduced intermediate variable creation and memory allocation.